### PR TITLE
Update thresh flag used

### DIFF
--- a/subcorticalparc_smk/workflow/rules/diffparc.smk
+++ b/subcorticalparc_smk/workflow/rules/diffparc.smk
@@ -61,7 +61,7 @@ rule probseg_to_binary_template_seed:
     container:
         config["singularity"]["neuroglia"]
     shell:
-        "fslmaths {input.seed} -thrP {params.thresh} -bin {output.mask} &> {log}"
+        "fslmaths {input.seed} -thr {params.thresh} -bin {output.mask} &> {log}"
 
 
 rule dilate_seed:


### PR DESCRIPTION
This changes the `fslmaths` call to use `-thr` instead of `-thrp`. The initial use of `-thrp` stemmed from a bug in the probabilistic seed that was used where values were greater than 1 (due to a direct sum of different probabilistic segmentations).