### PR TITLE
Add singularity call to `track_from_clusters` rule

### DIFF
--- a/subcorticalparc_smk/workflow/rules/tractmap.smk
+++ b/subcorticalparc_smk/workflow/rules/tractmap.smk
@@ -218,7 +218,7 @@ rule track_from_clusters:
         "diffparc_participant2"
     shell:
         "mkdir -p {output.probtrack_dir} && "
-        "singularity exec -e {params.extract_seed_cmd} && singularity exec -e --nv {params.container} "
+        "singularity exec -e {params.container} {params.extract_seed_cmd} && singularity exec -e --nv {params.container} "
         "probtrackx2_gpu --samples={params.bedpost_merged}  --mask={input.mask} --seed={output.probtrack_dir}/in_seed.nii.gz "
         "--seedref={output.probtrack_dir}/in_seed.nii.gz --nsamples={params.nsamples} "
         "--dir={output.probtrack_dir} {params.probtrack_opts} -V 2  &> {log}"

--- a/subcorticalparc_smk/workflow/rules/tractmap.smk
+++ b/subcorticalparc_smk/workflow/rules/tractmap.smk
@@ -218,7 +218,7 @@ rule track_from_clusters:
         "diffparc_participant2"
     shell:
         "mkdir -p {output.probtrack_dir} && "
-        "{params.extract_seed_cmd} && singularity exec -e --nv {params.container} "
+        "singularity exec -e {params.extract_seed_cmd} && singularity exec -e --nv {params.container} "
         "probtrackx2_gpu --samples={params.bedpost_merged}  --mask={input.mask} --seed={output.probtrack_dir}/in_seed.nii.gz "
         "--seedref={output.probtrack_dir}/in_seed.nii.gz --nsamples={params.nsamples} "
         "--dir={output.probtrack_dir} {params.probtrack_opts} -V 2  &> {log}"


### PR DESCRIPTION
In the rule `track_from_clusters`, `fslmaths` is called directly. This only works if `fslmaths` is installed on the system, otherwise it ambiguously errors out. 

This commit instead calls `fslmaths` from the `fsl_cuda` container that is being used for `probtrackx2_gpu` (adding `singularity exec -e {params.container}`prior to the `fslmaths` call).